### PR TITLE
properly catch `ValueError` thrown in `gmp_init()`

### DIFF
--- a/src/BigInteger/Adapter/Gmp.php
+++ b/src/BigInteger/Adapter/Gmp.php
@@ -52,6 +52,8 @@ class Gmp implements AdapterInterface
             $res = gmp_init($sign . $operand, $base);
         } catch (\TypeError $e) {
             $res = false;
+        } catch (\ValueError $e) {
+            $res = false;
         }
 
         restore_error_handler();


### PR DESCRIPTION
Without this

```
There were 5 errors:

1) LaminasTest\Math\BigInteger\Adapter\GmpTest::testInitReturnsFalse with data set #0 ('zzz')
ValueError: gmp_init(): Argument #1 ($num) is not an integer string

```

