### PR TITLE
Fixed a missing `}` in `getInteger()` due to merge-up conflict resolution

### DIFF
--- a/src/Rand.php
+++ b/src/Rand.php
@@ -80,6 +80,7 @@ abstract class Rand
                 0,
                 $e
             );
+        }
     }
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
There was a missing } in getInteger() and this Pull Request fixes this issue